### PR TITLE
Add analyze timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ client.analyze({bytecode: '0xf6'})
     console.log(err)
   })
 ```
+You can also specify the timeout in milliseconds to wait for the analysis to be
+done (the default is 10 seconds). For instance, to wait up to 5 seconds:
+```javascript
+client.analyze({bytecode: <contract_bytecode>, timeout: 5000})
+  .then(issues => {
+    console.log(issues)
+  }).catch(err => {
+    console.log(err)
+  })
+```
+
 
 See the example directory for some simple but runnable examples of how
 to use the client.

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ class Client {
 
       requester.do(options.bytecode, this.apiKey, this.apiUrl)
         .then(uuid => {
-          return poller.do(uuid, this.apiKey, this.apiUrl)
+          return poller.do(uuid, this.apiKey, this.apiUrl, undefined, options.timeout)
         }).then(issues => {
           resolve(issues)
         }).catch(err => {

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -1,5 +1,20 @@
-exports.do = (uuid, apiKey, apiUrl, pollStep = 1000) => {
-  return new Promise((resolve, reject) => {
+exports.do = (uuid, apiKey, apiUrl, pollStep = 1000, timeout = 10000) => {
+  let pollIntervalID = null
+  let timeoutID = null
+
+  const clearActions = () => {
+    clearTimeout(timeoutID)
+    clearInterval(pollIntervalID)
+  }
+
+  const timeoutPromise = new Promise((resolve, reject) => {
+    timeoutID = setTimeout(() => {
+      clearActions()
+      reject(new Error(`Timed out in ${timeout} ms.`))
+    }, timeout)
+  })
+
+  const pollPromise = new Promise((resolve, reject) => {
     const lib = apiUrl.protocol === 'http:' ? require('http') : require('https')
     const getOptions = {
       protocol: apiUrl.protocol,
@@ -15,11 +30,11 @@ exports.do = (uuid, apiKey, apiUrl, pollStep = 1000) => {
         getOptions,
         res => {
           if (res.statusCode === 401) {
-            clearInterval(intervalID)
+            clearActions()
             reject(new Error(`Unauthorized analysis request, API key: ${this.apiKey}`))
           }
           if (res.statusCode === 500) {
-            clearInterval(intervalID)
+            clearActions()
             reject(new Error('received error 500 from API server'))
           }
 
@@ -30,17 +45,22 @@ exports.do = (uuid, apiKey, apiUrl, pollStep = 1000) => {
             try {
               data = JSON.parse(rawData)
             } catch (err) {
-              clearInterval(intervalID)
+              clearActions()
               reject(err)
             }
             if (res.statusCode === 200) {
-              clearInterval(intervalID)
+              clearActions()
               resolve(data)
             }
           })
         }
       )
     }
-    const intervalID = setInterval(getFunc, pollStep)
+    pollIntervalID = setInterval(getFunc, pollStep)
   })
+
+  return Promise.race([
+    timeoutPromise,
+    pollPromise
+  ])
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "armlet",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "A Mythril Platform API client.",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -205,6 +205,23 @@ describe('main module', () => {
 
           await this.instance.analyze({bytecode: bytecode}).should.be.rejectedWith(Error, errorMsg)
         })
+
+        it('should pass timeout option to poller', async () => {
+          const timeout = 10
+
+          sinon.stub(requester, 'do')
+            .withArgs(bytecode, apiKey, parsedApiUrl)
+            .returns(new Promise(resolve => {
+              resolve(uuid)
+            }))
+          sinon.stub(poller, 'do')
+            .withArgs(uuid, apiKey, parsedApiUrl, undefined, timeout)
+            .returns(new Promise(resolve => {
+              resolve(issues)
+            }))
+
+          await this.instance.analyze({bytecode: bytecode, timeout: timeout}).should.eventually.equal(issues)
+        })
       })
     })
   })


### PR DESCRIPTION
Closes #3 

Adds a timeout option to poller, defaults to 10 seconds and can be set from the `analyze` method options.